### PR TITLE
Fix CUDA build paths

### DIFF
--- a/setup_codex_cuda.sh
+++ b/setup_codex_cuda.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 # 2) 빌드 디렉터리 준비
 mkdir -p build
-cd build
 
 # 3) nvcc로 컴파일
 
@@ -14,7 +13,7 @@ nvcc -std=c++20 \
   src/d_matrix.cu \
   src/database.cu \
   src/chess.cu \
-  -o codex_exp \
+  -o build/codex_exp \
   -lcurl \
   -lcurand \
   -Xcompiler="-pthread"


### PR DESCRIPTION
## Summary
- fix build script paths so nvcc compiles source files from repo root
- generate output under `build/`
- ensure file ends with newline

## Testing
- `shellcheck setup_codex_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845298237fc8322b2a5859c2b60e6ab