### PR TITLE
Implement 4-digit label handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ transformer 모듈을 적용한 체스 인공지능 만들기
 
 docker환경 불러오는 명령어:sudo docker run --rm -it --gpus all   -v "$(pwd):/workspace"   -w /workspace   codex-cuda-dev
 
+데이터셋의 라벨은 네 자리 숫자로 저장되며, 학습 네트워크의 출력층 또한 4개의 노드를 사용한다. `LoadingData()` 함수에서 라벨을 각 자리수로 분리하여 사용한다.
+
 

--- a/exp_sample/pradic_GOL_count.cu
+++ b/exp_sample/pradic_GOL_count.cu
@@ -21,9 +21,9 @@ int main(){
     ActivateLayer act1(128, 1, ActivationType::Tanh);
     Adam layer2(128, 64, 0.01, InitType::Xavier);
     ActivateLayer act2(64, 1, ActivationType::Tanh);
-    Adam outputLayer(64, 1, 0.01, InitType::Xavier);
-    ActivateLayer outAct(1, 1, ActivationType::Identity);
-    LossLayer loss(1, 1, LossType::MSE);
+    Adam outputLayer(64, 4, 0.01, InitType::Xavier);
+    ActivateLayer outAct(4, 1, ActivationType::Identity);
+    LossLayer loss(4, 1, LossType::MSE);
 
     const int epochs = 20;
     const int batchSize = 10;
@@ -86,7 +86,10 @@ int main(){
 
         d_matrix<double> pred = outAct.getOutput();
         pred.cpyToHost();
-        int count = static_cast<int>(std::round(pred(0,0)));
+        int count = 0;
+        for(int k=0; k<4; ++k){
+            count += static_cast<int>(std::round(pred(k,0))) * static_cast<int>(std::pow(10,k));
+        }
 
         std::ofstream ofs(result_path + "/sample_count_ver_" + std::to_string(idx+1) + ".txt");
         ofs << "=== sample " << idx+1 << " 결과 ===\n";

--- a/src/database.cu
+++ b/src/database.cu
@@ -330,9 +330,12 @@ std::vector<std::pair<d_matrix<double>, d_matrix<double>>> LoadingData() {
             label_index = std::stoi(line);
         }
 
-        d_matrix<double> label(1, 1); // 원-핫 벡터 초기화
-
-        label(0, 0) = label_index;
+        d_matrix<double> label(4, 1);
+        for(int k=0; k<4; ++k){
+            label(k,0) = label_index % 10;
+            label_index /= 10;
+        }
+        label.cpyToDev();
 
         dataset.emplace_back(input, label);
     }


### PR DESCRIPTION
## Summary
- split labels into four digits when loading data
- adjust neural net to output 4 nodes
- decode predictions using digits when saving
- document new label format

## Testing
- `bash setup_codex_cuda.sh` *(fails: nvcc terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6846d645b0888322bd7461ab2192edcb