### PR TITLE
Implement ID validation for weight files

### DIFF
--- a/src/perceptron.hpp
+++ b/src/perceptron.hpp
@@ -67,6 +67,7 @@ inline std::string to_string(InitType init) {
  
 inline std::string getCurrentTimestamp();
 
+
 typedef struct convoluteId{
         int inRow, inCol;
         int kRow, kCol;
@@ -94,6 +95,8 @@ class convolutionLayer{
         void feedforward(const d_matrix<double>& raw_input);
         void backprop(const d_matrix<double>& delta_flat);
         d_matrix<double>& getOutput();
+        void saveWeight();
+        void loadWeight(const std::string& path);
 };
 
 class perceptronLayer {
@@ -130,9 +133,7 @@ class perceptronLayer {
         void updateWeightInDev();
         // getOutput: 계층 출력 반환
         d_matrix<double>& getOutput();
-        // saveWeight/loadWeight: 가중치 저장/불러오기
-        void saveWeight();
-        void loadWeight(const std::string& path);
+        // 가중치 저장/불러오기는 파생 클래스에서 구현
 };
 
 // ActivateLayer-------------------------------------------------------------------------------------------------------------------
@@ -168,6 +169,8 @@ class ActivateLayer{
         d_matrix<double> d_Active(const d_matrix<double>& z);
         // 결과 반환
         const d_matrix<double>& getOutput() const ;
+        void saveLayer();
+        void loadLayer(const std::string& path);
 };
 
 // LossLayer--------------------------------------------------------------------------------------------------------------------------------
@@ -202,6 +205,8 @@ class LossLayer{
         double getLoss();
         // 손실 미분 반환
         d_matrix<double> getGrad();
+        void saveLayer();
+        void loadLayer(const std::string& path);
 };
 
 
@@ -240,7 +245,9 @@ public:
 
     virtual ~Adam();
 
-    void backprop(perceptronLayer* next, const d_matrix<double>& external_delta, const d_matrix<double>& act_deriv);   
+    void backprop(perceptronLayer* next, const d_matrix<double>& external_delta, const d_matrix<double>& act_deriv);
+    void saveWeight();
+    void loadWeight(const std::string& path);
 };
 
 typedef struct SGD_id{
@@ -263,9 +270,48 @@ public:
     virtual ~SGD();
 
     void backprop(perceptronLayer* next, const d_matrix<double>& external_delta, const d_matrix<double>& act_deriv);
+    void saveWeight();
+    void loadWeight(const std::string& path);
 };
 
 inline void loadCurruntModelCurcuits();
+
+// -----------------------------------------------------------------------------
+// ID 문자열 생성 유틸리티
+inline std::string exp_to_string(double v) {
+    if (v == 0) return "0";
+    int e = static_cast<int>(std::round(std::log10(1.0 / v)));
+    return "e" + std::to_string(e);
+}
+
+inline std::string to_string(const Adamid& id) {
+    return "A-" + std::to_string(id.i) + "-" + std::to_string(id.o) + "-" +
+           exp_to_string(id.lr) + "-" + to_string(id.Init) + "-" +
+           std::to_string(id.b1) + "-" + std::to_string(id.b2) + "-" +
+           exp_to_string(id.epsilon);
+}
+
+inline std::string to_string(const SGDid& id) {
+    return "S-" + std::to_string(id.i) + "-" + std::to_string(id.o) + "-" +
+           exp_to_string(id.lr) + "-" + to_string(id.Init);
+}
+
+inline std::string to_string(const convoluteid& id) {
+    return "C-" + std::to_string(id.inRow) + "*" + std::to_string(id.inCol) + "-" +
+           std::to_string(id.kRow) + "*" + std::to_string(id.kCol) + "-" +
+           std::to_string(id.numFilter) + "-" + exp_to_string(id.learning_rate) +
+           "-" + to_string(id.Init);
+}
+
+inline std::string to_string(const activeid& id) {
+    return "A" + std::to_string(id.row) + "-" + std::to_string(id.col) + "-" +
+           to_string(id.Act);
+}
+
+inline std::string to_string(const lossid& id) {
+    return "L" + std::to_string(id.row) + "-" + std::to_string(id.col) + "-" +
+           to_string(id.loss);
+}
 
 #endif
 


### PR DESCRIPTION
## Summary
- move perceptron weight save/load from base class to Adam and SGD subclasses
- store layer ID in binary files and verify IDs when loading
- extend convolution, activation and loss layer save/load with ID checks

## Testing
- `bash setup_build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853cca672b48322bf1be5692bae2b7d